### PR TITLE
Update streaming.json

### DIFF
--- a/blueprints/streaming/streaming.json
+++ b/blueprints/streaming/streaming.json
@@ -1741,6 +1741,7 @@
     }
   ],
   "Blueprints" : {
+    "blueprint_name": "uprush-test",
     "stack_name" : "HDP",
     "stack_version" : "2.2"
   }


### PR DESCRIPTION
You need blueprint_name 

In the logs this what i saw:
 Invalid blueprint: 'blueprint_name' under 'Blueprints' is missing from JSON.
